### PR TITLE
Fix comment for very large file size test

### DIFF
--- a/SecurityExplorer.Tests/Helpers/UnitTestCalculationHelper.cs
+++ b/SecurityExplorer.Tests/Helpers/UnitTestCalculationHelper.cs
@@ -58,7 +58,7 @@ namespace SecurityExplorer.Tests.Helpers
             //Assert.AreEqual(5, CalculationHelper.GetPowerForFileSize(1125899906842620)); //Petabyte
 
             //Assert.AreEqual(5, CalculationHelper.GetPowerForFileSize(1152921504606849000));
-            //Assert.AreEqual(6, CalculationHelper.GetPowerForFileSize(1152921504606850000)); //Etabyte
+            //Assert.AreEqual(6, CalculationHelper.GetPowerForFileSize(1152921504606850000)); //Exabyte
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
- fix comment text for very large file size assertion in UnitTestCalculationHelper

## Testing
- `dotnet build SecurityExplorer.Tests/SecurityExplorer.Tests.csproj` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406bc2d4a483238fa96c8b79ed4687