### PR TITLE
Rename decimal point test method

### DIFF
--- a/SecurityExplorer.Tests/Helpers/UnitTestCalculationHelper.cs
+++ b/SecurityExplorer.Tests/Helpers/UnitTestCalculationHelper.cs
@@ -15,7 +15,7 @@ namespace SecurityExplorer.Tests.Helpers
         }
 
         [TestMethod]
-        public void TestMethodGetDecimalPointPosition_()
+        public void TestMethodGetDecimalPointPosition_WithDecimal()
         {
             Assert.AreEqual(1, CalculationHelper.GetDecimalPointPosition(9.99));
             Assert.AreEqual(2, CalculationHelper.GetDecimalPointPosition(99.09));


### PR DESCRIPTION
## Summary
- rename `TestMethodGetDecimalPointPosition_` to `TestMethodGetDecimalPointPosition_WithDecimal`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406d9122088323b1e884150dfd170b