### PR TITLE
Fix file size formatting

### DIFF
--- a/SecurityExplorer/Helpers/CalculationHelper.cs
+++ b/SecurityExplorer/Helpers/CalculationHelper.cs
@@ -42,18 +42,22 @@ namespace SecurityExplorer.Helpers
             size /= Math.Pow(1024.0, power);
             size = Math.Round(size, 2);
 
+            string formattedSize = size % 1 == 0
+                ? size.ToString("F0", CultureInfo.InvariantCulture)
+                : size.ToString("F2", CultureInfo.InvariantCulture);
+
             switch(power)
             {
                 case 0:
-                    return $"{size} B";
+                    return $"{formattedSize} B";
                 case 1:
-                    return $"{size} KB";
+                    return $"{formattedSize} KB";
                 case 2:
-                    return $"{size} MB";
+                    return $"{formattedSize} MB";
                 case 3:
-                    return $"{size} GB";
+                    return $"{formattedSize} GB";
                 case 4:
-                    return $"{size} TB";
+                    return $"{formattedSize} TB";
                 default:
                     throw new ArgumentException(nameof(power));
             }


### PR DESCRIPTION
## Summary
- fix `GetFormatterFileSize` to avoid trailing decimals

## Testing
- `dotnet test SecurityExplorer/SecurityExplorer.sln` *(fails: None of the projects specified contain packages to restore)*

------
https://chatgpt.com/codex/tasks/task_e_68406f3b71d883238c4bf683d3e2b3fd